### PR TITLE
Feat: 컨텐츠 삭제, 에피소드 전체 토글 기능

### DIFF
--- a/checklist/views.py
+++ b/checklist/views.py
@@ -1,3 +1,5 @@
+from gc import is_finalized
+from os import stat
 import requests
 
 from django.shortcuts import get_object_or_404
@@ -5,7 +7,9 @@ from django.shortcuts import get_object_or_404
 from rest_framework import views
 from rest_framework.status import *
 from rest_framework.response import Response
+from calculator.serializers import RuntimeSerializer
 from checklist.models import MovieContent, TVContent
+from calculator.models import Runtime
 
 from overtheott.settings import TMDB_API_KEY
 from .serializers import *
@@ -52,14 +56,11 @@ class MovieSearchView(views.APIView):
             result['provider'] = provider_list
             data.append(result)
 
-
-            
         return Response({'message': '영화 목록 검색 성공', 'data': data}, status=HTTP_200_OK)
-    
 
     def post(self, request):
         movie_data = {
-            'user': 1,
+            'user': request.user.id,
             'title': request.data.get('title'),
             'tmdb_id': request.data.get('tmdb_id'),
             'poster': request.data.get('poster'),
@@ -73,7 +74,7 @@ class MovieSearchView(views.APIView):
             serializer.save()
             return Response({'message': '영화 저장 성공', 'data': serializer.data}, status=HTTP_200_OK)
         else:
-            return Response({'message': '영화 저장 실패'}, serializer.errors, status=HTTP_400_BAD_REQUEST)
+            return Response({'message': '영화 저장 실패', 'data': serializer.errors}, status=HTTP_400_BAD_REQUEST)
 
 
 class TVSearchView(views.APIView):
@@ -130,18 +131,20 @@ class TVSearchView(views.APIView):
             result['tmdb_id'] = detail_response['id']
             result['title'] = detail_response['name']
             result['poster'] = detail_response['backdrop_path']
-            result['episode_run_time'] = detail_response['episode_run_time'][0]
+            if detail_response['episode_run_time']:
+                result['episode_run_time'] = detail_response['episode_run_time'][0]
+            else:
+                result['episode_run_time'] = 0
             result['season'] = season
             result['provider'] = provider_list
 
             data.append(result)
 
-
         return Response({'message': 'TV 목록 검색 성공', 'data': data}, status=HTTP_200_OK)
 
     def post(self, request):
         tv_data = {
-            'user': 1,
+            'user': request.user.id,
             'title': request.data.get('title'),
             'tmdb_id': request.data.get('tmdb_id'),
             'poster': request.data.get('poster'),
@@ -165,11 +168,10 @@ class TVSearchView(views.APIView):
                 if episode_serializer.is_valid():
                     episode_serializer.save()
 
-
             return Response({'message': 'TV 저장 성공', 'data': serializer.data}, status=HTTP_200_OK)
 
         else:
-            return Response({'message': 'TV 저장 실패'}, serializer.errors, status=HTTP_400_BAD_REQUEST)
+            return Response({'message': 'TV 저장 실패', 'data': serializer.errors}, status=HTTP_400_BAD_REQUEST)
 
 
 class MovieListView(views.APIView):
@@ -195,12 +197,19 @@ class MovieDetailView(views.APIView):
     def post(self, request, pk):
         movie_id = request.data.get('movie_id')
         movie = get_object_or_404(MovieContent, pk=movie_id)
+        runtime = get_object_or_404(Runtime.objects.filter(
+            ott__user=request.user.id, ott__ott=movie.provider))
 
-        movie.is_finished = True
-        movie.save()
-
+        if movie.is_finished:
+            movie.is_finished = False
+            runtime.total_runtime -= movie.runtime
+        else:
+            movie.is_finished = True
+            runtime.total_runtime += movie.runtime
+        runtime.save()
         movie_serializer = MovieSerializer(movie)
-        return Response({'message': '영화 시청 기록 저장 성공', 'data': movie_serializer.data})
+        movie.save()
+        return Response({'message': '영화 시청 기록 저장 성공', 'data': movie_serializer.data}, status=HTTP_200_OK)
 
 
 class TVListView(views.APIView):
@@ -224,19 +233,26 @@ class TVDetailView(views.APIView):
     def post(self, request, pk):
         episode_id = request.data.get('episode_id')
         episode = get_object_or_404(Episode, pk=episode_id)
+        runtime = get_object_or_404(Runtime.objects.filter(
+            ott__user=request.user.id, ott__ott=episode.tv.provider))
+        tv = episode.tv
 
-        episode.is_finished = True
+        if episode.is_finished:
+            episode.is_finished = False
+            tv.episode_status -= 1
+            runtime.total_runtime -= tv.runtime
+        else:
+            episode.is_finished = True
+            tv.episode_status += 1
+            runtime.total_runtime += tv.runtime
+        runtime.save()
+        episode_serializer = EpisodeSerializer(episode)
         episode.save()
-
-        tv = get_object_or_404(TVContent, pk=pk)
-        tv.episode_status += 1
 
         if tv.total_episode == tv.episode_status:
             tv.is_finished = True
-
+        else:
+            tv.is_finished = False
         tv.save()
 
-        episode_serializer = EpisodeSerializer(episode)
-
-        return Response({'message': 'TV 시청 기록 저장 성공', 'data': episode_serializer.data})
-
+        return Response({'message': 'TV 시청 기록 저장 성공', 'data': episode_serializer.data}, status=HTTP_200_OK)


### PR DESCRIPTION
코드 변경 이유
- 체크리스트에서 컨텐츠 삭제, tv 에피소드 한꺼번에 체크하기

위험 / 개선 가능성
- serializer를 이렇게 안써도 되는건지 모르겠음. 수정할수록 restful하지 않아짐.
- TVContent에서 provider를 SubscribingOTT 참조 외래키로 하면 필터하지 않을 수 있음.
- 클라이언트에서 tv와 movie를 어떻게 구분할지

관련 스크린샷
![image](https://user-images.githubusercontent.com/69039161/183435346-4f4d3036-8eb0-490f-91ea-00a91e20ebff.png)
