### PR TITLE
Fix: 월별 런타임 객체 생성 코드

### DIFF
--- a/account/models.py
+++ b/account/models.py
@@ -93,3 +93,6 @@ class SubscribingOTT(models.Model):
     @property
     def pay_amount(self):
         return self.ott.fee/self.share
+
+    def __str__(self):
+        return f'{self.ott.ott}'

--- a/account/views.py
+++ b/account/views.py
@@ -65,7 +65,7 @@ class SubscribingOTTView(views.APIView):
         return Response({'message': '구독 중인 OTT 생성 실패', 'error': serializer.errors}, status=HTTP_400_BAD_REQUEST)
 
     def get(self, request):
-        otts = SubscribingOTT.objects.filter(user=request.user)
+        otts = SubscribingOTT.objects.all()
         serializer = SubscribingOTTSerializer(otts, many=True)
         return Response({'message': '구독 중인 OTT 조회 성공', 'data': serializer.data}, status=HTTP_200_OK)
 

--- a/calculator/models.py
+++ b/calculator/models.py
@@ -1,20 +1,24 @@
 from django.db import models
-from account.models import SubscribingOTT, OTT
+from account.models import SubscribingOTT
 
 # Create your models here.
 
 
 class Runtime(models.Model):
-    ott = models.ForeignKey(SubscribingOTT, on_delete=models.CASCADE)
+    ott = models.ForeignKey(
+        SubscribingOTT, on_delete=models.CASCADE, related_name='runtimes')
     year = models.IntegerField()
     month = models.IntegerField()
-    total_runtime = models.IntegerField()
+    total_runtime = models.IntegerField(default=0)
 
-    # @property
-    # def won_per_min(self):
-    #     won_per_min = self.ott.ott.fee / self.total_runtime
-    #     return won_per_min
+    @property
+    def won_per_min(self):
+        won_per_min = self.ott.ott.fee / self.total_runtime
+        return won_per_min
 
-    # @property
-    # def ott_name(self):
-    #     return self.ott.ott.ott
+    @property
+    def ott_name(self):
+        return self.ott.ott.ott
+
+    def __str__(self):
+        return f'{self.ott_name}'


### PR DESCRIPTION
**코드 변경 이유**
런타임 증가/감소시킬 때 그 달의 첫 증가/감소라면 객체를 생성해야함. 

**문제점**
이번 달에 본 컨텐츠/에피소드를 다음 달에 해제하면 다음 달은 런타임이 음수가 됨.
이걸 해결하려면 에피소드 별로 is_finished 가 true로 변한 날짜도 저장하는 필드가 있어야함. 